### PR TITLE
Reduce possible matches with autocompletion

### DIFF
--- a/vmbot.py
+++ b/vmbot.py
@@ -353,7 +353,8 @@ class VMBot(MUCJabberBot):
             return 'Can\'t find a matching system!'
         if (autocompleteItem):
             cur.execute("SELECT typeID, typeName FROM invTypes "
-                        "WHERE typeName LIKE :name;", {'name' : '%'+item+'%'})
+                        "WHERE typeName LIKE :name AND marketGroupID IS NOT NULL "
+                        "AND marketGroupID < 100000;", {'name' : '%'+item+'%'})
         else:
             cur.execute("SELECT typeID, typeName FROM invTypes "
                         "WHERE UPPER(typeName) = UPPER(:name);", {'name' : item})


### PR DESCRIPTION
(21:02:42) thirteen_fish: joker_gates: there's a field in the database that indicates an item is on the market
(21:04:25) thirteen_fish: marketgroupId
(21:05:35) thirteen_fish: interwebs claim WHERE marketGroupID IS NOT NULL and marketGroupID < 100000 will do it and limit to eve only