### PR TITLE
Deletion changes and chown command

### DIFF
--- a/vmbot.py
+++ b/vmbot.py
@@ -618,6 +618,7 @@ class VMBot(MUCJabberBot):
                 if (self.longreply(mess, reply, receiver = receiver)):
                     return "Sent a PM to {}.".format(receiver)
                 else:
+                    # &#8203; is a zero-width space (http://en.wikipedia.org/wiki/Zero-width_space#Encoding)
                     return "&#8203;{}: {}".format(receiver, reply)
             if (self.longreply(mess, reply)):
                 return "Sent a PM to you."
@@ -890,6 +891,7 @@ class VMBot(MUCJabberBot):
     def pimpsay(self, mess, args):
         '''[text] - Like fishsay but blacker'''
         if (len(args) > 0):
+            # &#8203; is a zero-width space (http://en.wikipedia.org/wiki/Zero-width_space#Encoding)
             return "&#8203;{} {}".format(args, random.choice(self.pimpisms))
         else:
             return random.choice(self.pimpisms)

--- a/vmbot.py
+++ b/vmbot.py
@@ -636,7 +636,7 @@ class VMBot(MUCJabberBot):
         cur.execute("SELECT `value` FROM `metadata` WHERE `type` = 'version';")
         res = cur.fetchall()
         if (len(res) == 1 and res[0][0] != self.cache_version):
-            cur.execute("DELETE FROM `articles`")
+            cur.execute("DROP TABLE `articles`")
         conn.commit()
 
         cur.execute("INSERT OR REPLACE INTO `metadata` (`type`, `value`) VALUES (:type, :version);", {"type":"version", "version":self.faq_version})
@@ -1124,7 +1124,7 @@ class VMBot(MUCJabberBot):
             cur.execute("SELECT value FROM metadata WHERE type='version';")
             res = cur.fetchall()
             if (len(res) == 1 and res[0][0] != self.cache_version):
-                cur.execute("DELETE FROM cache")
+                cur.execute("DROP TABLE cache;")
             conn.commit()
 
             cur.execute("INSERT OR REPLACE INTO metadata VALUES (:type, :version);", {"type":"version","version":self.cache_version})

--- a/vmbot.py
+++ b/vmbot.py
@@ -651,7 +651,7 @@ class VMBot(MUCJabberBot):
         cur.execute("SELECT `value` FROM `metadata` WHERE `type` = 'version';")
         res = cur.fetchall()
         if (len(res) == 1 and res[0][0] != self.faq_version):
-            cur.execute("DROP TABLE `articles`")
+            cur.execute("DROP TABLE `articles`;")
         conn.commit()
 
         cur.execute("INSERT OR REPLACE INTO `metadata` (`type`, `value`) VALUES (:type, :version);",

--- a/vmbot.py
+++ b/vmbot.py
@@ -574,6 +574,8 @@ class VMBot(MUCJabberBot):
             cur.execute("SELECT `ID`, `keywords`, `title`, `content` FROM `articles` WHERE `ID` = :id AND NOT `hidden`;", {"id":int(needle)})
         except ValueError:
             pass
+        except sqlite3.OperationalError:
+            return "Error: Data is missing"
         res = cur.fetchall()
 
         # Keyword based search
@@ -625,7 +627,10 @@ class VMBot(MUCJabberBot):
         conn = sqlite3.connect("faq.sqlite")
         cur = conn.cursor()
 
-        cur.execute("SELECT `ID`, `title` FROM `articles`" + (" WHERE NOT `hidden`" if (not showHidden) else "") + ";")
+        try:
+            cur.execute("SELECT `ID`, `title` FROM `articles`" + (" WHERE NOT `hidden`" if (not showHidden) else "") + ";")
+        except sqlite3.OperationalError:
+            return "Error: Data is missing"
         res = cur.fetchall()
 
         reply = "1) {} (<i>ID: {}</i>)".format(res[0][1], res[0][0])
@@ -677,6 +682,8 @@ class VMBot(MUCJabberBot):
             cur.execute("SELECT `createdBy`, `modifiedBy` FROM `articles` WHERE `ID` = :id AND NOT `hidden`;", {"id":int(id)});
         except ValueError:
             return "Can't parse the ID"
+        except sqlite3.OperationalError:
+            return "Error: Data is missing"
         res = cur.fetchall()
         if (len(res) == 0):
             return "Error: No match"
@@ -705,6 +712,8 @@ class VMBot(MUCJabberBot):
             cur.execute("SELECT `title`, `createdBy`, `modifiedBy` FROM `articles` WHERE `ID` = :id AND NOT `hidden`;", {"id":int(id)})
         except ValueError:
             return "Can't parse the ID"
+        except sqlite3.OperationalError:
+            return "Error: Data is missing"
         res = cur.fetchall()
         if (len(res) == 0):
             return "Error: No articles"
@@ -729,6 +738,8 @@ class VMBot(MUCJabberBot):
             cur.execute("SELECT `createdBy` FROM `articles` WHERE `ID` = :id AND NOT `hidden`;", {"id":int(id)});
         except ValueError:
             return "Can't parse the ID"
+        except sqlite3.OperationalError:
+            return "Error: Data is missing"
         res = cur.fetchall()
         if (len(res) == 0):
             return "Error: No match"
@@ -753,6 +764,8 @@ class VMBot(MUCJabberBot):
             cur.execute("SELECT `createdBy` FROM `articles` WHERE `ID` = :id AND `hidden`;", {"id":int(id)});
         except ValueError:
             return "Can't parse the ID"
+        except sqlite3.OperationalError:
+            return "Error: Data is missing"
         res = cur.fetchall()
         if (len(res) == 0):
             return "Error: No match"

--- a/vmbot.py
+++ b/vmbot.py
@@ -618,7 +618,7 @@ class VMBot(MUCJabberBot):
                 if (self.longreply(mess, reply, receiver = receiver)):
                     return "Sent a PM to {}.".format(receiver)
                 else:
-                    return " {}: ".format(receiver) + reply
+                    return "&#8203;{}: {}".format(receiver, reply)
             if (self.longreply(mess, reply)):
                 return "Sent a PM to you."
             else:
@@ -890,7 +890,7 @@ class VMBot(MUCJabberBot):
     def pimpsay(self, mess, args):
         '''[text] - Like fishsay but blacker'''
         if (len(args) > 0):
-            return " " + args + " " + random.choice(self.pimpisms)
+            return "&#8203;{} {}".format(args, random.choice(self.pimpisms))
         else:
             return random.choice(self.pimpisms)
     


### PR DESCRIPTION
### Changed deleting to making articles hidden
- The `hidden` column is used to determine if an article is visible to users. It is 0 (visible) by default
- `faq delete` will set `hidden = 1` (hide it)
- New command `faq revert` will set `hidden = 0` (show it)
- Added `faq index [show hidden]` to list all entries, including hidden ones
- Changed `faq_version` to 2
- Added missing help texts
- `faq revert` will only show non-hidden entries]
- Cleaned up code to be more readable
- [VMBot FAQ DB Conversion Script](https://gist.github.com/TheJokr/ae3e3aca413e677681cd) can be used to update the DB from v1 to v2. Make sure to run this before firing up the bot.

### Added `faq chown`
- `faq chown <ID> <new Author>` changes ownership of an article to `<new Author>` in order to let `<new Author>` edit the document

### Improved Error Messages
- There is a proper error message for missing tables now